### PR TITLE
Multiple changes:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Pending
+
+## 2015-08-04
+
+- docker upstart job removes /var/run/docker.sock if it's a directory (#1)
+- docker daemon now uses devicemapper storage driver
+- ecs-agent & empire upstart jobs now remove old containers when restarting
+- non-master branch pushes are now not published, and only build in us-east-1

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ download-packer:
 	if [ ! -f $(HOME)/bin/packer ]; then curl --location -O https://dl.bintray.com/mitchellh/packer/packer_0.8.2_linux_amd64.zip && unzip -d $(HOME)/bin packer_0.8.2_linux_amd64.zip; fi
 
 build:
-	set -o pipefail; packer -machine-readable build -color=false ./packer.json | tee -a $(CIRCLE_ARTIFACTS)/packer.out
+	set -o pipefail; packer -machine-readable build -color=false $(TEMPLATE) | tee -a $(CIRCLE_ARTIFACTS)/packer.out

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,4 @@ download-packer:
 
 build:
 	set -o pipefail; packer -machine-readable build -color=false $(TEMPLATE) | tee -a $(CIRCLE_ARTIFACTS)/packer.out
+	/usr/sbin/get_packer_amis $(CIRCLE_ARTIFACTS)/packer.out > $(CIRCLE_ARTIFACTS)/amis.yml

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
 SHELL=/bin/bash
 
+ifeq ($(CIRCLE_BRANCH),master)
+	TEMPLATE = ./packer.json
+else
+	TEMPLATE = ./packer.json.dev
+fi
+
 us-east-1:
-	packer build --only=empire-us-east-1 ./packer.json
+	packer build --only=empire-us-east-1 $(TEMPLATE)
 
 us-west-1:
-	packer build --only=empire-us-west-1 ./packer.json
+	packer build --only=empire-us-west-1 $(TEMPLATE)
 
 us-west-2:
-	packer build --only=empire-us-west-2 ./packer.json
+	packer build --only=empire-us-west-2 $(TEMPLATE)
 
 ami-all:
-	packer build ./packer.json
+	packer build $(TEMPLATE)
 
 download-packer:
 	mkdir -p $(HOME)/bin

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifeq ($(CIRCLE_BRANCH),master)
 	TEMPLATE = ./packer.json
 else
 	TEMPLATE = ./packer.json.dev
-fi
+endif
 
 us-east-1:
 	packer build --only=empire-us-east-1 $(TEMPLATE)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 SHELL=/bin/bash
 
 ifeq ($(CIRCLE_BRANCH),master)
+	# builds in us-east-1, us-west-1, us-west-2 and exposes to the world
 	TEMPLATE = ./packer.json
 else
+	# Only builds in us-east-1, and doesn't expose to the world
 	TEMPLATE = ./packer.json.dev
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ download-packer:
 
 build:
 	set -o pipefail; packer -machine-readable build -color=false $(TEMPLATE) | tee -a $(CIRCLE_ARTIFACTS)/packer.out
-	/usr/sbin/get_packer_amis $(CIRCLE_ARTIFACTS)/packer.out > $(CIRCLE_ARTIFACTS)/amis.yml
+	./files/get_packer_amis $(CIRCLE_ARTIFACTS)/packer.out > $(CIRCLE_ARTIFACTS)/amis.yml

--- a/ansible/roles/aws_ecs/files/etc/init/ecs_agent.conf
+++ b/ansible/roles/aws_ecs/files/etc/init/ecs_agent.conf
@@ -22,4 +22,8 @@ end script
 
 exec /usr/bin/docker run --name ecs-agent --env-file=/etc/empire/env/ecs_agent.env -v /var/run/ecs_agent:/data -v /var/run/docker.sock:/var/run/docker.sock -v /var/log/ecs:/log -p 127.0.0.1:51678:51678 $IMAGE
 
-post-stop exec sleep 2
+post-stop script
+    /usr/bin/docker stop -t 2 ecs-agent || true
+    /usr/bin/docker rm ecs-agent || true
+    sleep 2
+end script

--- a/ansible/roles/aws_ecs/files/etc/init/ecs_agent.conf
+++ b/ansible/roles/aws_ecs/files/etc/init/ecs_agent.conf
@@ -8,7 +8,7 @@ respawn limit 100 1
 
 # Needed to find /root/.dockercfg
 env HOME="/root"
-env IMAGE=amazon/amazon-ecs-agent@sha256:54e98d053d0fd6735732e2c17054ab5d78b40be9d20a628fce993dc789240399 # v1.2.1 tag
+env IMAGE=amazon/amazon-ecs-agent@sha256:72c02d9a96340e4381c70b4355289e204b36e7e667352eed8df4d0e2f2d308a4 # v1.3.1 tag
 export HOME
 
 pre-start script

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -11,10 +11,10 @@
 - apt: name=ca-certificates
   tags: 
     - build_ami
-- apt_repository: repo='deb https://get.docker.com/ubuntu docker main' state=present
+- apt_repository: repo='deb https://apt.dockerproject.org/repo ubuntu-{{ansible_distribution_release}} main' state=present
   tags: 
     - build_ami
-- apt_key: url=http://get.docker.io/gpg
+- apt_key: keyserver=p80.pool.sks-keyservers.net id=58118E89F3A912897C070ADBF76221572C52609D
   tags: 
     - build_ami
 - apt: update_cache=yes
@@ -27,15 +27,6 @@
 - file: path=/etc/empire/env owner=root group=root mode=0644 state=directory
   tags: 
     - build_ami
-
-# TODO: Determine usefulness
-#- copy: src=root/.dockercfg.{{r101_environment}} dest=/root/.dockercfg owner=root group=root mode=0600
-#  when: r101_environment is defined
-#  ignore_errors: yes
-#- set_fact:
-#    ansible_cron_minute1: "{{30 | mod_mac_addr }}"
-#    ansible_cron_minute2: "{{30 | mod_mac_addr + 30 }}"
-#- cron: name=ansible cron_file=ansible user=root minute="{{ansible_cron_minute1}},{{ansible_cron_minute2}}" job="/sbin/start ansible"
 
 - apt: name=awscli
   tags: 

--- a/ansible/roles/docker/files/etc/default/docker
+++ b/ansible/roles/docker/files/etc/default/docker
@@ -1,0 +1,14 @@
+# Docker Upstart and SysVinit configuration file
+
+# Customize location of Docker binary (especially for development testing).
+#DOCKER="/usr/local/bin/docker"
+
+# Use DOCKER_OPTS to modify the daemon startup options.
+#DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"
+DOCKER_OPTS="--storage-driver=devicemapper"
+
+# If you need Docker to use an HTTP proxy, it can also be specified here.
+#export http_proxy="http://127.0.0.1:3128/"
+
+# This is also a handy place to tweak where Docker's temporary files go.
+#export TMPDIR="/mnt/bigdrive/docker-tmp"

--- a/ansible/roles/docker/files/etc/init/docker.conf
+++ b/ansible/roles/docker/files/etc/init/docker.conf
@@ -1,0 +1,66 @@
+description "Docker daemon"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [!2345]
+limit nofile 524288 1048576
+limit nproc 524288 1048576
+
+respawn
+
+kill timeout 20
+
+pre-start script
+	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
+	if grep -v '^#' /etc/fstab | grep -q cgroup \
+		|| [ ! -e /proc/cgroups ] \
+		|| [ ! -d /sys/fs/cgroup ]; then
+		exit 0
+	fi
+	if ! mountpoint -q /sys/fs/cgroup; then
+		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+	fi
+	(
+		cd /sys/fs/cgroup
+		for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+			mkdir -p $sys
+			if ! mountpoint -q $sys; then
+				if ! mount -n -t cgroup -o $sys cgroup $sys; then
+					rmdir $sys || true
+				fi
+			fi
+		done
+	)
+end script
+
+script
+	# modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
+	DOCKER=/usr/bin/$UPSTART_JOB
+	DOCKER_OPTS=
+	if [ -f /etc/default/$UPSTART_JOB ]; then
+		. /etc/default/$UPSTART_JOB
+	fi
+        # Remove /var/run/docker.sock if it's a directory
+        if [ -d /var/run/docker.sock ]
+        then
+            echo "/var/run/docker.sock is a directory, removing."
+            rm -rf /var/run/docker.sock
+        fi
+	exec "$DOCKER" -d $DOCKER_OPTS
+end script
+
+# Don't emit "started" event until docker.sock is ready.
+# See https://github.com/docker/docker/issues/6647
+post-start script
+	DOCKER_OPTS=
+	if [ -f /etc/default/$UPSTART_JOB ]; then
+		. /etc/default/$UPSTART_JOB
+	fi
+	if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
+		while ! [ -e /var/run/docker.sock ]; do
+			initctl status $UPSTART_JOB | grep -qE "(stop|respawn)/" && exit 1
+			echo "Waiting for /var/run/docker.sock"
+			sleep 0.1
+		done
+		echo "/var/run/docker.sock is up"
+	fi
+end script

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -26,6 +26,8 @@
 - copy: src=etc/default/docker dest=/etc/default/docker owner=root group=root mode=0644
   tags:
     - build_ami
+  notify:
+    - restart_docker
 
 - apt: name=linux-image-extra-{{ansible_kernel}}
   tags: 
@@ -39,6 +41,12 @@
 - apt: name=docker-engine
   tags: 
     - build_ami
+
+- copy: src=etc/init/docker.conf dest=/etc/init/docker.conf owner=root group=root mode=0644
+  tags:
+    - build_ami
+  notify:
+    - restart_docker
 
 # Create docker_maid cron job
 - copy: src=usr/sbin/docker_maid dest=/usr/sbin/docker_maid owner=root group=root mode=0755

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -32,7 +32,7 @@
 - apt: name=apparmor
   tags: 
     - build_ami
-- apt: name=lxc-docker
+- apt: name=docker-engine
   tags: 
     - build_ami
 

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -23,6 +23,10 @@
   ignore_errors: yes
   when: new_docker_fs|changed
 
+- copy: src=etc/default/docker dest=/etc/default/docker owner=root group=root mode=0644
+  tags:
+    - build_ami
+
 - apt: name=linux-image-extra-{{ansible_kernel}}
   tags: 
     - build_ami

--- a/ansible/roles/empire/files/etc/init/empire.conf
+++ b/ansible/roles/empire/files/etc/init/empire.conf
@@ -18,4 +18,8 @@ end script
 
 exec /usr/bin/docker run -p 8080:8080 -l app=empire --env-file /etc/empire/env/empire.env -v /var/run/docker.sock:/var/run/docker.sock -v /etc/empire/dockercfg:/root/.dockercfg --name empire $IMAGE server -automigrate=true
 
-post-stop exec sleep 2
+post-stop script
+    /usr/bin/docker stop -t 2 empire || true
+    /usr/bin/docker rm empire || true
+    sleep 2
+end script

--- a/files/get_packer_amis
+++ b/files/get_packer_amis
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+import sys
+
+try:
+    packer_file = sys.argv[1]
+except IndexError:
+    print "syntax: %s <packer_output_file>" % sys.argv[0]
+    sys.exit(1)
+
+for line in open(packer_file):
+    line = line.strip()
+    parts = line.split(',')
+    if parts[2] != 'artifact':
+        continue
+    if parts[4] != 'id':
+        continue
+    region, ami = parts[-1].split(':')
+    print "%s: %s" % (region, ami)

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -29,9 +29,6 @@ mv /tmp/packer_files/ansible.conf /etc/init/ansible.conf
 mv /tmp/packer_files/make_dockercfg /usr/sbin/make_dockercfg
 chmod +x /usr/sbin/make_dockercfg
 
-mv /tmp/packer_files/get_packer_amis /usr/sbin/get_packer_amis
-chmod +x /usr/sbin/get_packer_amis
-
 mkdir -p /etc/empire
 mv /tmp/ansible /etc/empire/ansible
 

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -29,6 +29,9 @@ mv /tmp/packer_files/ansible.conf /etc/init/ansible.conf
 mv /tmp/packer_files/make_dockercfg /usr/sbin/make_dockercfg
 chmod +x /usr/sbin/make_dockercfg
 
+mv /tmp/packer_files/get_packer_amis /usr/sbin/get_packer_amis
+chmod +x /usr/sbin/get_packer_amis
+
 mkdir -p /etc/empire
 mv /tmp/ansible /etc/empire/ansible
 

--- a/packer.json.dev
+++ b/packer.json.dev
@@ -1,0 +1,48 @@
+{
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "name": "empire-us-east-1",
+      "access_key": "",
+      "secret_key": "",
+      "region": "us-east-1",
+      "source_ami": "ami-c135f3aa",
+      "instance_type": "m3.medium",
+      "ssh_username": "ubuntu",
+      "ssh_timeout": "5m",
+      "ami_name": "DEV IMAGE Empire PaaS {{isotime | clean_ami_name}}",
+      "ami_users": [
+        "427009882155",
+        "415355184500",
+        "990501462471",
+        "066251891493",
+        "559544594286"
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "files",
+      "destination": "/tmp/packer_files"
+    },
+    {
+      "type": "file",
+      "source": "ansible",
+      "destination": "/tmp/ansible"
+    },
+    {
+      "type": "shell",
+      "pause_before": "60s",
+      "execute_command": "chmod +x {{ .Path  }}; {{ .Vars  }} sudo {{ .Path  }}",
+      "script": "files/setup.sh"
+    },
+    {
+      "type": "ansible-local",
+      "command": "chmod +x /tmp/packer-provisioner-ansible-local/hosts; EMPIRE_HOSTGROUP=empire_ami sudo -E ansible-playbook --tags build_ami ",
+      "playbook_file": "./ansible/site.yml",
+      "inventory_file": "files/hosts",
+      "playbook_dir": "./ansible"
+    }
+  ]
+}


### PR DESCRIPTION
- docker upstart job removes /var/run/docker.sock if it's a directory (#1)
- use new ubuntu package repo & package name (docker-engine) for docker package
- docker daemon now uses devicemapper storage driver
- ecs-agent & empire upstart jobs now remove old containers when restarting
- Only pushes to the master branch in this repo will be published publicly.
- Publish 'amis.yml' as artifact after build, should make it easy to find new ami values

Tested in the example stacker stack environment, seems to work well.
