### PR TITLE
Lock to docker 1.7.0, fix ecs tcs mounts

### DIFF
--- a/ansible/roles/aws_ecs/files/etc/init/ecs_agent.conf
+++ b/ansible/roles/aws_ecs/files/etc/init/ecs_agent.conf
@@ -20,7 +20,7 @@ pre-start script
     fi
 end script
 
-exec /usr/bin/docker run --name ecs-agent --env-file=/etc/empire/env/ecs_agent.env -v /var/run/ecs_agent:/data -v /var/run/docker.sock:/var/run/docker.sock -v /var/log/ecs:/log -p 127.0.0.1:51678:51678 $IMAGE
+exec /usr/bin/docker run --name ecs-agent --env-file=/etc/empire/env/ecs_agent.env -v /var/run/ecs_agent:/data -v /var/run/docker.sock:/var/run/docker.sock -v /var/log/ecs:/log -v /var/run/docker/execdriver:/var/lib/docker/execdriver:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro -p 127.0.0.1:51678:51678 $IMAGE
 
 post-stop script
     /usr/bin/docker stop -t 2 ecs-agent || true

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -38,7 +38,7 @@
 - apt: name=apparmor
   tags: 
     - build_ami
-- apt: name=docker-engine
+- apt: name=docker-engine=1.7.0-0~trusty
   tags: 
     - build_ami
 

--- a/ansible/roles/empire/files/etc/init/empire.conf
+++ b/ansible/roles/empire/files/etc/init/empire.conf
@@ -8,7 +8,7 @@ respawn limit 100 1
 
 # Needed to find /root/.dockercfg
 env HOME="/root"
-env IMAGE=remind101/empire@sha256:444375959f3d4a3801d57d6fdcce4f90392d760dd095726ff5ffe43e283f5432 # https://github.com/remind101/empire/commits/f5ae48001e681f3780cc3257a3d9fe05d36d5463
+env IMAGE=remind101/empire@sha256:66c04d4724a64647ef76533458e497e8c32ab102509129248abf27e45d734a99 # https://github.com/remind101/empire/commits/7ef0587f2372e2d95b1101492468570738b9d858
 export HOME
 
 pre-start script


### PR DESCRIPTION
After docker 1.7.0 we (Remind) have seen this issue pop up:

https://github.com/docker/docker/issues/13914

Now that this is closed:

https://github.com/docker/docker/pull/16001

We can use the new docker-engine packages, but with an old version. I'm
moving the empire_ami back to docker 1.7.0 till 13914 above is fixed.

As well, this should fix ECS stats - we just needed a bunch of volumes,
per:

https://github.com/aws/amazon-ecs-agent/issues/174

Doing this internally @ Remind fixed this.
