### PR TITLE
Get awscli from pip instead of Ubuntu

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -28,9 +28,6 @@
   tags: 
     - build_ami
 
-- apt: name=awscli
-  tags: 
-    - build_ami
 - apt: name=python-pip state=absent
   tags: 
     - build_ami
@@ -42,4 +39,7 @@
     - build_ami
 - pip: name=boto
   tags: 
+    - build_ami
+- pip: name=awscli
+  tags:
     - build_ami


### PR DESCRIPTION
This will get the most recent version of awscli from pip. Fixes #9 
