### PR TITLE
Add private docker repo credentials to /root/.dockercfg

### DIFF
--- a/ansible/roles/aws_ecs/tasks/main.yml
+++ b/ansible/roles/aws_ecs/tasks/main.yml
@@ -4,7 +4,7 @@
     - build_ami
 - shell: /usr/sbin/make_dockercfg {{docker_user|quote}} {{docker_pass|quote}} {{docker_email|quote}} {{docker_registry|quote}}
   register: dockercfg
-- copy: 'content="{{dockercfg.stdout}}" dest=/root/.dockercfg owner=root group=root mode=0600'
+- copy: content="{{dockercfg.stdout}}" dest=/root/.dockercfg owner=root group=root mode=0600
 - copy: src=etc/init/ecs_agent.conf dest=/etc/init/ecs_agent.conf
   notify: 
     - restart_ecs_agent

--- a/ansible/roles/aws_ecs/tasks/main.yml
+++ b/ansible/roles/aws_ecs/tasks/main.yml
@@ -4,6 +4,7 @@
     - build_ami
 - shell: /usr/sbin/make_dockercfg {{docker_user|quote}} {{docker_pass|quote}} {{docker_email|quote}} {{docker_registry|quote}}
   register: dockercfg
+- copy: 'content="{{dockercfg.stdout}}" dest=/root/.dockercfg owner=root group=root mode=0600'
 - copy: src=etc/init/ecs_agent.conf dest=/etc/init/ecs_agent.conf
   notify: 
     - restart_ecs_agent


### PR DESCRIPTION
I've added some extra docker containers to run on instance boot up using Upstart. They can't start up though without the private docker registry credentials, which this PR adds.

Are there downsides to this? It was mentioned in this file:
https://github.com/ianneub/empire_ami/blob/fade40ee30021e9b5aafefa84e6ff049ec5c8e0d/ansible/roles/logspout/files/etc/init/logspout.conf#L9

But doesn't seem to exist in the rest of the Ansible config.
