### PR TITLE
Respawn ansible if it fails during boot.

### DIFF
--- a/files/ansible.conf
+++ b/files/ansible.conf
@@ -4,6 +4,7 @@ start on (stopped cloud-final)
 stop on runlevel [!2345]
 
 task
+respawn
 
 script
     BASE=/etc/empire
@@ -32,3 +33,5 @@ script
 
     echo "[$(date)] Finished ansible"
 end script
+
+post-stop exec sleep 15


### PR DESCRIPTION
This will help to prevent nodes from failing to start up, due to 3rd party failures.
