### PR TITLE
No longer need to import SEED

### DIFF
--- a/files/ansible.conf
+++ b/files/ansible.conf
@@ -17,9 +17,6 @@ script
     then
         echo "== Error: Missing ${SEED}, exiting."
         exit 1
-    else
-        echo "== Loading $SEED"
-        . $SEED
     fi
 
     if [ ! -d ${PLAYBOOKDIR} ]


### PR DESCRIPTION
We don't actually use any of the variables in `$SEED` anywhere in the
script, other than for ansible, and we already import them for ansible
with `env $(cat $SEED)`, which is actually safer when variables include
values with sensitive shell strings (like `&`).

Fixes GH-15
