### PR TITLE
Create releases when master is built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ download-packer:
 build:
 	set -o pipefail; CHANGES="$(CHANGES)" BRANCH="$(BRANCH)" GITINFO="$(BRANCH)@$(shell git log -1 --pretty=%H)" $(PACKERCMD)
 	./files/get_packer_amis $(CIRCLE_ARTIFACTS)/packer.out > $(CIRCLE_ARTIFACTS)/amis.yml
+
+release: build
+	./bin/release

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+user=$CIRCLE_PROJECT_USERNAME
+repo=$CIRCLE_PROJECT_REPONAME
+tag=$(TZ=UTC date "+%Y-%m-%dT%H-%M-%SZ")
+description=$(mktemp)
+
+build_url="https://circleci.com/gh/$user/$repo/$CIRCLE_BUILD_NUM"
+cat $CIRCLE_ARTIFACTS/amis.yaml >> $description
+echo "Built from $build_url" >> $description
+
+exec github-release release \
+    --user ${user} \
+    --repo ${repo} \
+    --tag ${tag} \
+    --description "$(cat $description)"

--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,9 @@ test:
   override:
     - cd ~/empire_ami; MACHINE=true make build:
         timeout: 1200
+
+deployment:
+  release:
+    branch: master
+    commands:
+      - make release

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ dependencies:
   cache_directories:
     - /home/ubuntu/bin
   pre:
+    - go get github.com/aktau/github-release
     - cd ~/empire_ami; make download-packer
 
 test:


### PR DESCRIPTION
Release will contain published ami info

This will make it easier to see which AMIs you should reference within stacker.
